### PR TITLE
samedec,sameold: optional "fast" end-of-message decoding

### DIFF
--- a/crates/samedec/README.md
+++ b/crates/samedec/README.md
@@ -189,6 +189,13 @@ may still contain invalid dates or unknown event codes.
 
 SAME trailers which indicate the end of message are output as `NNNN`.
 
+SAME messages are always transmitted three times for redundancy. `samedec` will
+use all three transmissions, together, to improve decoding. Normally, only one
+line will be output for each header or trailer. When the `--fast-eom` option is
+set, `samedec` won't wait for all three repetitions of the trailer. All trailers
+which successfully decode will print an `NNNN` line. This option permits you to
+detect the end of the message more quickly than the default setting.
+
 [`dsame`](https://github.com/cuppa-joe/dsame)
 is a python decoder which can produce human-readable text from this output.
 The [`sameold`](https://crates.io/crates/sameold) crate also understands how to

--- a/crates/samedec/src/main.rs
+++ b/crates/samedec/src/main.rs
@@ -99,6 +99,12 @@ fn main() {
                 .help("Issue demo warning (DMO) and exit"),
         )
         .arg(
+            Arg::with_name("fast_eom")
+                .long("fast-eom")
+                .takes_value(false)
+                .help("Output one \"NNNN\" for each EOM received. Ends child processes sooner."),
+        )
+        .arg(
             Arg::with_name("dc-blocker-len")
                 .long("dc-blocker-len")
                 .help("DC Blocker filter length (fsym)")
@@ -205,6 +211,7 @@ fn main() {
             str::parse(matches.value_of("preamble-max-errors").unwrap())
                 .expect("--preamble-max-errors: expect integer"),
         )
+        .with_fast_end_of_message(matches.occurrences_of("fast_eom") >= 1)
         .build();
 
     // file setup: locks stdin in case we need it

--- a/crates/sameold/src/framing.rs
+++ b/crates/sameold/src/framing.rs
@@ -490,10 +490,11 @@ fn message_prefix_errors(inp: u32) -> u32 {
 
 // True if the burst starts with the EOM sequence
 fn message_prefix_is_eom(inp: &[u8]) -> bool {
-    match std::str::from_utf8(inp) {
-        Ok(s) => s.starts_with("NNNN"),
-        _ => false,
+    if inp.len() < 4 {
+        return false;
     }
+
+    &inp[0..4] == ['N' as u8, 'N' as u8, 'N' as u8, 'N' as u8]
 }
 
 // Two-of-three bit voting
@@ -617,7 +618,11 @@ mod tests {
     #[test]
     fn test_message_prefix_is_eom() {
         assert!(!message_prefix_is_eom(&[]));
+        assert!(!message_prefix_is_eom("NNN".as_bytes()));
         assert!(message_prefix_is_eom("NNNNzzzz!".as_bytes()));
+        assert!(message_prefix_is_eom(&[
+            'N' as u8, 'N' as u8, 'N' as u8, 'N' as u8, 10, 0
+        ]));
     }
 
     #[test]

--- a/crates/sameold/src/receiver.rs
+++ b/crates/sameold/src/receiver.rs
@@ -392,7 +392,11 @@ impl From<&SameReceiverBuilder> for SameReceiver {
             eqcfg.regularization(),
             Some(crate::waveform::PREAMBLE_SYNC_WORD),
         );
-        let framer = Framer::new(cfg.frame_prefix_max_errors(), cfg.frame_max_invalid());
+        let framer = Framer::new(
+            cfg.frame_prefix_max_errors(),
+            cfg.frame_max_invalid(),
+            cfg.fast_end_of_message(),
+        );
 
         let samples_until_next_ted = symsync.samples_per_ted();
 


### PR DESCRIPTION
When playing back or recording a SAME voice message, it is sometimes desirable to terminate the playback as quickly as possible. SAME voice messages themselves are unlikely to nuisance-trip the decoder. Error correction for the EOM—which carries no other data—is largely unnecessary. We can generally terminate recording as soon as we receive the first EOM ("`NNNN`"), without needing to wait for all three repetitions of it.
be printed per message.

This patch adds a decoding option to `sameold` and a new CLI option to `samedec`. The new `--fast-eom` option causes the framer to output an end-of-message indication for every "`NNNN`" byte sequence decoded. This potentially detects the end-of-message more quickly. As a side-effect, up to three `NNNN` lines may be printed per message.