### PR TITLE
sameold: decode EOMs faster

### DIFF
--- a/crates/samedec/README.md
+++ b/crates/samedec/README.md
@@ -172,22 +172,32 @@ broken.
 >     samedec -r 22050
 > ```
 >
-> should produce one output message per line:
+> should produce the following output:
 >
 > ```txt
 > ZCZC-EAS-RWT-012057-012081-012101-012103-012115+0030-2780415-WTSP/TV-
+> NNNN
+> NNNN
 > NNNN
 > ```
 
 When `samedec` receives a SAME message, the message is printed to stdout. The
 printout uses the SAME ASCII encoding that is transmitted over the air.
 
-Exactly one message is printed per line. Only messages are printed. SAME headers
-which indicate the beginning of a message are prefixed with `ZCZC`. Some
-validation is performed to ensure that headers have the correct format, but they
-may still contain invalid dates or unknown event codes.
+Exactly one message is printed per line. Only messages are printed. SAME
+*headers* which indicate the beginning of a message are prefixed with `ZCZC`.
+Some validation is performed to ensure that headers have the correct format, but
+they may still contain invalid dates or unknown event codes.
 
-SAME trailers which indicate the end of message are output as `NNNN`.
+SAME messages are always transmitted three times for redundancy. When decoding
+the message header, `samedec` will use all three transmissions together to
+improve decoding. Only one line will be output for the `ZCZC` header.
+
+SAME *trailers* which indicate the end of message are output as `NNNN`. The
+trailers are not subject to the same error-correction process as the headers.
+All trailers which successfully decode will print an `NNNN` line. Up to three
+of these lines will be printed per SAME message. This decoding strategy permits
+end of message to be detected more quickly.
 
 [`dsame`](https://github.com/cuppa-joe/dsame)
 is a python decoder which can produce human-readable text from this output.

--- a/crates/samedec/src/app.rs
+++ b/crates/samedec/src/app.rs
@@ -73,8 +73,11 @@ where
 
         let mut alerting = State::<Alerting>::from(dmo);
         alerting.until_message_end(&cfg, receiver, &mut input.take(duration_message));
-        alerting = State::<Alerting>::from(Message::EndOfMessage);
-        alerting.until_message_end(&cfg, receiver, &mut std::iter::once(0i16));
+
+        for _i in 0..3 {
+            alerting = State::<Alerting>::from(Message::EndOfMessage);
+            alerting.until_message_end(&cfg, receiver, &mut std::iter::once(0i16));
+        }
     } else {
         // live mode: look for messages in a loop
         let mut waiting = State::<Waiting>::new();

--- a/crates/sameold/src/lib.rs
+++ b/crates/sameold/src/lib.rs
@@ -48,7 +48,7 @@
 //! // Create a SameReceiver with your audio sampling rate
 //! // Sound cards typically run at 44100 Hz or 48000 Hz. Use
 //! // an input rate of at least 8000 Hz.
-//! let mut rx = SameReceiverBuilder::new(22050)
+//! let mut rx = SameReceiverBuilder::new(48000)
 //!     .with_agc_bandwidth(0.05)        // AGC bandwidth at symbol rate, < 1.0
 //!     .with_agc_gain_limits(1.0/(i16::MAX as f32), 1.0/200.0)  // for i16
 //!     .with_squelch_power(0.10, 0.05)  // squelch open/close power, 0.0 < power < 1.0
@@ -57,7 +57,7 @@
 //!
 //! // let audiosrc be an iterator which outputs audio samples,
 //! // such as a BufReader bound to stdin or a file, in f32
-//! // format at the sampling rate (here 22050 Hz)
+//! // format at the sampling rate (here 48000 Hz)
 //! let audiosrc = some_audio_source_iterator();
 //! for msg in rx.iter_messages(audiosrc) {
 //!     match msg {
@@ -96,8 +96,9 @@
 //! * describes the event; and
 //! * provides instructions to the listener.
 //!
-//! This crate decodes the digital headers which summarize the message.
-//! An example header, as received "off the wire" in ASCII format, is:
+//! This crate decodes the digital headers and trailers which summarize
+//! the message. An example header, as received "off the wire" in ASCII
+//! format, is:
 //!
 //! ```txt
 //! ZCZC-WXR-RWT-012345-567890-888990+0015-0321115-KLOX/NWS-
@@ -130,6 +131,15 @@
 //! let first_location = hdr.location_str_iter().next();
 //! assert_eq!(Some("012345"), first_location);
 //! ```
+//!
+//! SAME messages are always transmitted three times for redundancy.
+//! When decoding the message header, `sameold` will use all three
+//! transmissions together to improve decoding. Only one
+//! [`Message::StartOfMessage`] is output for all three header transmissions.
+//! The trailers which denote the end of the message are **not** subject to
+//! this error-correction process. One [`Message::EndOfMessage`] is
+//! output for every trailer received. There may be up to three
+//! `EndOfMessage` output for every complete SAME message.
 //!
 //! ## Background
 //!

--- a/crates/sameold/src/message/message.rs
+++ b/crates/sameold/src/message/message.rs
@@ -468,10 +468,7 @@ impl MessageHeader {
 
 impl fmt::Display for Message {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Message::StartOfMessage(msg) => msg.fmt(f),
-            Message::EndOfMessage => PREFIX_MESSAGE_END.fmt(f),
-        }
+        self.as_str().fmt(f)
     }
 }
 
@@ -489,7 +486,7 @@ impl TryFrom<String> for Message {
     fn try_from(inp: String) -> Result<Self, Self::Error> {
         if inp.starts_with(PREFIX_MESSAGE_START) {
             Ok(Message::StartOfMessage(MessageHeader::try_from(inp)?))
-        } else if inp.starts_with(PREFIX_MESSAGE_END) {
+        } else if inp.starts_with(&PREFIX_MESSAGE_END[0..2]) {
             Ok(Message::EndOfMessage)
         } else {
             Err(MessageDecodeErr::UnrecognizedPrefix)
@@ -504,7 +501,7 @@ impl TryFrom<(String, &[u8])> for Message {
     fn try_from(inp: (String, &[u8])) -> Result<Self, Self::Error> {
         if inp.0.starts_with(PREFIX_MESSAGE_START) {
             Ok(Message::StartOfMessage(MessageHeader::try_from(inp)?))
-        } else if inp.0.starts_with(PREFIX_MESSAGE_END) {
+        } else if inp.0.starts_with(&PREFIX_MESSAGE_END[0..2]) {
             Ok(Message::EndOfMessage)
         } else {
             Err(MessageDecodeErr::UnrecognizedPrefix)
@@ -737,5 +734,8 @@ mod tests {
         let msg = Message::try_from("NNNN".to_owned()).expect("bad msg");
         assert_eq!(Message::EndOfMessage, msg);
         assert_eq!("NNNN", &format!("{}", msg));
+
+        let msg = Message::try_from("NN".to_owned()).expect("bad msg");
+        assert_eq!(Message::EndOfMessage, msg);
     }
 }


### PR DESCRIPTION
Per the SAME spec [1 pp. 19], receivers are not required to wait for three bursts of "`NNNN`" to end a message. One burst which starts with "`NN`" is sufficient.

To improve standards-compliance, add dedicated decoding logic for the EOM which is independent of the error-correction. Every individual "`NNNN`" burst which decodes will output a separate `Message::EndOfMessage`. The framer now accepts two `N` characters as an EOM. The framer must still decode all four `N` characters with no greater than `max_prefix_bit_errors` in order to qualify as an EOM.

This is an API-breaking change. samedec documentation is updated.

Supersedes and closes #5.

References
1. https://www.nws.noaa.gov/directives/sym/pd01017012curr.pdf

