### PR TITLE
Update EAS specs to support IPAWS and EAS Vendors.

### DIFF
--- a/crates/samedec/src/app.rs
+++ b/crates/samedec/src/app.rs
@@ -269,7 +269,7 @@ impl From<State<Alerting>> for State<Waiting> {
 
 // Create a demonstration message
 fn make_demo_message(at: &DateTime<Utc>) -> Message {
-    let msg_string = format!("ZCZC-EAS-DMO-999000+0015-{}-N0CALL-", at.format("%j%H%M"));
+    let msg_string = format!("ZCZC-EAS-DMO-999000+0015-{}-N0 CALL -", at.format("%j%H%M"));
     Message::StartOfMessage(MessageHeader::new(msg_string).expect("unable to create DMO message"))
 }
 

--- a/crates/sameold/src/framing.rs
+++ b/crates/sameold/src/framing.rs
@@ -517,9 +517,13 @@ fn bit_vote_parity(b0: u8, b1: u8, b2: u8) -> (u8, u32) {
 //
 // Allowed characters include the following ASCII:
 // - Uppercase letters
+// - Lowercase letters
 // - Numbers
 // - Minus sign (`-`)
 // - Plus sign (`+`)
+// - Question mark (`?`)
+// - Open parentheses (`(`)
+// - Close parentheses (`)`)
 // - Slash (`/`)
 // - Space (` `)(might be encountered in callsign field)
 //
@@ -530,15 +534,23 @@ fn bit_vote_parity(b0: u8, b1: u8, b2: u8) -> (u8, u32) {
 fn is_allowed_byte(c: u8) -> bool {
     const MINUS: u8 = '-' as u8;
     const PLUS: u8 = '+' as u8;
+    const QUESTION_MARK: u8 = '?' as u8;
+    const OPEN_PARENTHESES: u8 = '(' as u8;
+    const CLOSE_PARENTHESES: u8 = ')' as u8;
     const SLASH: u8 = '/' as u8;
     const SPACE: u8 = ' ' as u8;
     const NUMBERS: [u8; 2] = ['0' as u8, '9' as u8];
     const UPPER_ALPHA: [u8; 2] = ['A' as u8, 'Z' as u8];
+    const LOWER_ALPHA: [u8; 2] = ['a' as u8, 'z' as u8];
 
     c == MINUS
         || (c >= NUMBERS[0] && c <= NUMBERS[1])
         || (c >= UPPER_ALPHA[0] && c <= UPPER_ALPHA[1])
+        || (c >= LOWER_ALPHA[0] && c <= LOWER_ALPHA[1])
         || c == SLASH
+        || c == QUESTION_MARK
+        || c == OPEN_PARENTHESES
+        || c == CLOSE_PARENTHESES
         || c == PLUS
         || c == SPACE
 }

--- a/crates/sameold/src/framing.rs
+++ b/crates/sameold/src/framing.rs
@@ -524,7 +524,10 @@ fn bit_vote_parity(b0: u8, b1: u8, b2: u8) -> (u8, u32) {
 // - Question mark (`?`)
 // - Open parentheses (`(`)
 // - Close parentheses (`)`)
+// - Open brackets (`[`)
+// - Close brackets (`]`)
 // - Period (`.`)
+// - Underscore (`_`)
 // - Comma (`,`)
 // - Slash (`/`)
 // - Space (` `)(might be encountered in callsign field)
@@ -539,7 +542,10 @@ fn is_allowed_byte(c: u8) -> bool {
     const QUESTION_MARK: u8 = '?' as u8;
     const OPEN_PARENTHESES: u8 = '(' as u8;
     const CLOSE_PARENTHESES: u8 = ')' as u8;
+    const OPEN_BRACKETS: u8 = '[' as u8;
+    const CLOSE_BRACKETS: u8 = ']' as u8;
     const PERIOD: u8 = '.' as u8;
+    const UNDERSCORE: u8 = '_' as u8;
     const COMMA: u8 = ',' as u8;
     const SLASH: u8 = '/' as u8;
     const SPACE: u8 = ' ' as u8;
@@ -555,7 +561,10 @@ fn is_allowed_byte(c: u8) -> bool {
         || c == QUESTION_MARK
         || c == OPEN_PARENTHESES
         || c == CLOSE_PARENTHESES
+        || c == OPEN_BRACKETS
+        || c == CLOSE_BRACKETS
         || c == PERIOD
+        || c == UNDERSCORE
         || c == COMMA
         || c == PLUS
         || c == SPACE

--- a/crates/sameold/src/framing.rs
+++ b/crates/sameold/src/framing.rs
@@ -524,6 +524,8 @@ fn bit_vote_parity(b0: u8, b1: u8, b2: u8) -> (u8, u32) {
 // - Question mark (`?`)
 // - Open parentheses (`(`)
 // - Close parentheses (`)`)
+// - Period (`.`)
+// - Comma (`,`)
 // - Slash (`/`)
 // - Space (` `)(might be encountered in callsign field)
 //
@@ -537,6 +539,8 @@ fn is_allowed_byte(c: u8) -> bool {
     const QUESTION_MARK: u8 = '?' as u8;
     const OPEN_PARENTHESES: u8 = '(' as u8;
     const CLOSE_PARENTHESES: u8 = ')' as u8;
+    const PERIOD: u8 = '.' as u8;
+    const COMMA: u8 = ',' as u8;
     const SLASH: u8 = '/' as u8;
     const SPACE: u8 = ' ' as u8;
     const NUMBERS: [u8; 2] = ['0' as u8, '9' as u8];
@@ -551,6 +555,8 @@ fn is_allowed_byte(c: u8) -> bool {
         || c == QUESTION_MARK
         || c == OPEN_PARENTHESES
         || c == CLOSE_PARENTHESES
+        || c == PERIOD
+        || c == COMMA
         || c == PLUS
         || c == SPACE
 }

--- a/crates/sameold/src/message/message.rs
+++ b/crates/sameold/src/message/message.rs
@@ -569,7 +569,7 @@ const PREFIX_MESSAGE_END: &str = "NNNN";
 fn check_header(hdr: &str) -> Result<(usize, usize), MessageDecodeErr> {
     lazy_static! {
         static ref RE: Regex =
-            Regex::new(r"^ZCZC-[A-Z]{3}-[A-Z]{3}(-[0-9]{6})+(\+[0-9]{4}-[0-9]{7}-.{3,8}-)")
+            Regex::new(r"^ZCZC-[[:alpha:]]{3}-[[:alpha:]]{3}(-[0-9]{6})+(\+[0-9]{4}-[0-9]{7}-.{3,8}-)")
                 .expect("bad SAME regexp");
     }
 


### PR DESCRIPTION
 - Fixes internal demo alerts to have all callsigns be 8 characters long ([NWSI 10-1712, Section A.2.11](http://www.nws.noaa.gov/directives/sym/pd01017012curr.pdf))
 - Adds support for lowercase Event and Originator Codes (See Digital Alert Systems DASDEC-II and DASDEC-III use of custom alerts and messaging indorsed by FEMA and IPAWS)
 - Adds support for lowercase characters as well as `().,?` in callsigns for backwards compatibility with Trilithic/Viavi, SAGE, DAS, Gorman, and TFT units. (See EAS units special characters and lowercase callsigns indorsed by FEMA and IPAWS)
 
 These changes add small features to SAMEDEC and SAMEOLD to allow supporting more units that are indorsed by FEMA and IPAWS, as well as conforming closer to the NWS Specifications on SAME messaging.
 
 These changes also add repairs to fix SAMEDEC refusing to decode valid alerts sent by hardware units into a monitoring computer, or over the air via SDR due to lack of support of special callsign characters supported by these units.
 
 If you would like hardware decoding logs from many of these units, I can provide documentation from the units, along with examples of the EAS headers produced by them, and/or menu / front panel photos to prove these functionalities.