### PR TITLE
sameold: log the full text of each SAME burst

### DIFF
--- a/crates/sameold/src/framing.rs
+++ b/crates/sameold/src/framing.rs
@@ -258,7 +258,7 @@ impl Framer {
         // if we're reading a frame, that frame is done
         match self.state {
             State::DataRead(ref mut msg, _) => {
-                info!("burst: ended: after {} bytes", msg.len());
+                info!("burst: ended: \"{}\"", String::from_utf8_lossy(msg));
 
                 // add to our list of completed bursts
                 self.symbol_count_last_burst = symbol_count;


### PR DESCRIPTION
Output an info-level debugging message with the contents of each individual SAME burst, as they are received.

The burst text is guaranteed to be valid utf-8, and within the maximum size limit for a SAME message, but absolutely *no* other guarantees are made. Since SAME does not have an end-of-message indicator, the log line may have trailing garbage characters.

Sample output (via `samedec -v`):

    INFO  sameold::framing     > burst: ended: "NNNN�UUU"