### PR TITLE
github-ci: add CI tests for all major platforms

### DIFF
--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -1,0 +1,75 @@
+name: Rust Test
+
+on:
+  push:
+    branches: [ "release/**" ]
+  pull_request:
+    branches: [ "develop" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test_linux:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Record environment
+      run: cat /etc/os-release && cargo version
+    - uses: actions/cache@v3
+      name: Restore Rust cache
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose
+  test_windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Record environment
+      shell: bash
+      run: cargo version
+    - uses: actions/cache@v3
+      name: Restore Rust cache
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Build
+      shell: bash
+      run: cargo build --verbose
+    - name: Run tests
+      shell: bash
+      run: cargo test --verbose
+  test_macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Record environment
+        run: cargo version
+      - uses: actions/cache@v3
+        name: Restore Rust cache
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose


### PR DESCRIPTION
Use the available Github Runners to automate CI testing on Linux, Windows, and macOS. Rust dependencies are cached to speed up the build.
    
CI binaries are not used for releases at present. For that, we would want to curate our environments very carefully—probably with containers.