### PR TITLE
sameold,samedec: remove deprecated chrono functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,9 +99,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "num-integer",

--- a/crates/samedec/src/app.rs
+++ b/crates/samedec/src/app.rs
@@ -277,12 +277,12 @@ fn make_demo_message(at: &DateTime<Utc>) -> Message {
 mod tests {
     use super::*;
 
-    use chrono::{Duration, TimeZone};
+    use chrono::{Duration, TimeZone, Utc};
     use sameold::EventCode;
 
     #[test]
     fn test_make_demo_message() {
-        let tm = Utc.ymd(2020, 12, 31).and_hms(23, 22, 00);
+        let tm = Utc.with_ymd_and_hms(2020, 12, 31, 23, 22, 00).unwrap();
         let msg = make_demo_message(&tm);
         let msg = match msg {
             Message::StartOfMessage(hdr) => hdr,


### PR DESCRIPTION
Update to chrono 0.4.23 and replace deprecated functions.