### PR TITLE
samedec: CLI Improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,15 +21,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +83,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,17 +108,40 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "once_cell",
  "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "termcolor",
+ "terminal_size",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -144,6 +164,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +192,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -184,6 +231,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
+
+[[package]]
 name = "js-sys"
 version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +256,12 @@ name = "libc"
 version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "log"
@@ -319,6 +378,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
 name = "paste"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +397,30 @@ checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
 dependencies = [
  "env_logger",
  "log",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -380,6 +469,20 @@ name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
+name = "rustix"
+version = "0.35.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c825b8aa8010eb9ee99b75f05e10180b9278d161583034d7574c9d617aeada"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.36.1",
+]
 
 [[package]]
 name = "samedec"
@@ -438,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
@@ -454,7 +557,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -481,12 +584,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "terminal_size"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "40ca90c434fd12083d1a6bdcbe9f92a14f96c8a1ba600ba451734ac334521f7a"
 dependencies = [
- "unicode-width",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -528,16 +632,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
+name = "version_check"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasm-bindgen"
@@ -623,3 +721,103 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,6 +543,7 @@ name = "samedec"
 version = "0.2.4"
 dependencies = [
  "anyhow",
+ "atty",
  "byteorder",
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,7 +59,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -108,14 +114,14 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.26"
+version = "4.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e"
+checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
 dependencies = [
- "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
+ "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
@@ -124,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.21"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
@@ -209,6 +215,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +249,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes 1.0.5",
+ "rustix 0.36.8",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,15 +287,21 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "linux-raw-sys"
 version = "0.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "log"
@@ -478,16 +518,31 @@ checksum = "72c825b8aa8010eb9ee99b75f05e10180b9278d161583034d7574c9d617aeada"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes",
+ "io-lifetimes 0.7.5",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.0.46",
  "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes 1.0.5",
+ "libc",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "samedec"
 version = "0.2.4"
 dependencies = [
+ "anyhow",
  "byteorder",
  "chrono",
  "clap",
@@ -589,7 +644,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ca90c434fd12083d1a6bdcbe9f92a14f96c8a1ba600ba451734ac334521f7a"
 dependencies = [
- "rustix",
+ "rustix 0.35.9",
  "windows-sys 0.42.0",
 ]
 
@@ -740,6 +795,30 @@ name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc 0.42.1",

--- a/crates/samedec/Cargo.toml
+++ b/crates/samedec/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 [dependencies]
 sameold = {path = "../sameold", version = "0.2.4"}
 byteorder = "^1.4"
-clap = "^2.33"
+clap = {version = "^4", features = ["color", "derive", "wrap_help"]}
 log = "^0.4"
 pretty_env_logger = "^0.4"
 

--- a/crates/samedec/Cargo.toml
+++ b/crates/samedec/Cargo.toml
@@ -11,8 +11,9 @@ readme = "README.md"
 
 [dependencies]
 sameold = {path = "../sameold", version = "0.2.4"}
+anyhow = "^1"
 byteorder = "^1.4"
-clap = {version = "^4", features = ["color", "derive", "wrap_help"]}
+clap = {version = "^4.1", features = ["color", "derive", "wrap_help"]}
 log = "^0.4"
 pretty_env_logger = "^0.4"
 

--- a/crates/samedec/Cargo.toml
+++ b/crates/samedec/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 [dependencies]
 sameold = {path = "../sameold", version = "0.2.4"}
 anyhow = "^1"
+atty = "^0.2"
 byteorder = "^1.4"
 clap = {version = "^4.1", features = ["color", "derive", "wrap_help"]}
 log = "^0.4"

--- a/crates/samedec/src/app.rs
+++ b/crates/samedec/src/app.rs
@@ -32,10 +32,10 @@ use std::process::Child;
 
 use byteorder::{NativeEndian, WriteBytesExt};
 use chrono::{DateTime, Utc};
-use clap::ArgMatches;
 use log::{debug, error, warn};
 use sameold::{Message, MessageHeader, SameReceiver};
 
+use crate::cli::Args;
 use crate::spawner;
 
 /// Run the application
@@ -47,23 +47,11 @@ use crate::spawner;
 ///
 /// In demo mode (see `args`), we print a demo message, wait, and
 /// then exit.
-pub fn run<I>(args: &ArgMatches, receiver: &mut SameReceiver, mut input: I)
+pub fn run<I>(args: &Args, receiver: &mut SameReceiver, mut input: I)
 where
     I: Iterator<Item = i16>,
 {
-    let child_args: Vec<&str> = match args.values_of("CHILD") {
-        Some(child_args) => child_args.collect(),
-        None => Vec::default(),
-    };
-
-    let cfg = Config {
-        child_args,
-        input_rate_str: args.value_of("rate").unwrap(),
-        quiet: args.occurrences_of("quiet") >= 1,
-        demo: args.occurrences_of("demo") >= 1,
-    };
-
-    if cfg.demo {
+    if args.demo {
         // demo mode: issue a DMO message, run the child for eight seconds,
         // and exit
         let duration_message = (receiver.input_rate() * 8) as usize;
@@ -72,28 +60,19 @@ where
         warn!("demonstration (--demo) mode: the following messages are NOT LIVE!");
 
         let mut alerting = State::<Alerting>::from(dmo);
-        alerting.until_message_end(&cfg, receiver, &mut input.take(duration_message));
+        alerting.until_message_end(&args, receiver, &mut input.take(duration_message));
 
         for _i in 0..3 {
             alerting = State::<Alerting>::from(Message::EndOfMessage);
-            alerting.until_message_end(&cfg, receiver, &mut std::iter::once(0i16));
+            alerting.until_message_end(&args, receiver, &mut std::iter::once(0i16));
         }
     } else {
         // live mode: look for messages in a loop
         let mut waiting = State::<Waiting>::new();
         while let Some(alerting) = waiting.until_message_start(receiver, &mut input) {
-            waiting = alerting.until_message_end(&cfg, receiver, &mut input);
+            waiting = alerting.until_message_end(&args, receiver, &mut input);
         }
     }
-}
-
-/// Configuration
-#[derive(Clone, Debug)]
-struct Config<'args> {
-    child_args: Vec<&'args str>,
-    input_rate_str: &'args str,
-    quiet: bool,
-    demo: bool,
 }
 
 #[derive(Debug)]
@@ -146,7 +125,7 @@ impl State<Alerting> {
     /// found or the iterator is exhausted.
     pub fn until_message_end<I>(
         mut self,
-        config: &Config<'_>,
+        config: &Args,
         receiver: &mut SameReceiver,
         input: &mut I,
     ) -> State<Waiting>
@@ -163,17 +142,19 @@ impl State<Alerting> {
                 Message::EndOfMessage => break, // → Waiting
             };
 
-            if config.child_args.is_empty() {
+            if config.child.is_empty() {
                 debug!("no child process to spawn");
                 return self.into(); // → Waiting
             }
 
+            let input_rate_string = format!("{}", config.rate);
+
             // try to spawn a child
             let mut child = match spawner::spawn(
-                config.child_args[0],
-                &config.child_args[1..],
+                &config.child[0],
+                &config.child[1..],
                 &hdr,
-                &config.input_rate_str,
+                &input_rate_string,
             ) {
                 Ok(child) => child,
                 Err(err) => {

--- a/crates/samedec/src/cli.rs
+++ b/crates/samedec/src/cli.rs
@@ -1,0 +1,164 @@
+use clap::value_parser;
+use clap::Parser;
+
+/// Standard input filename
+const STDIN_FILE: &str = "-";
+
+const USAGE_SHORT: &str = r#"
+This program accepts raw PCM samples in signed 16-bit (i16) format, at the given sampling --rate, and decodes any SAME headers that are present. Decoded headers are printed in their ASCII representation.
+
+See --help for more details.
+
+ALWAYS TEST YOUR DECODING SETUP!
+"#;
+
+const USAGE_LONG: &str = r#"
+This program accepts raw PCM samples in signed 16-bit (i16) format, at the given sampling --rate, and decodes any SAME headers that are present. Decoded headers are printed in their ASCII representation.
+
+You can pipe in an audio file with sox
+
+    sox input.wav -t raw -r 22.5k -e signed -b 16 -c 1 - \
+        | samedec -r 22050
+
+Arguments which follow "--" will be used to spawn a child process. The child process will have the input audio signal piped to its standard input. You can use this to play or store SAME messages.
+
+    parec --channels 1 --format s16ne \
+      --rate 22050 --latency-msec 500 \
+        | samedec -r 22050 -- pacat \
+            --channels 1 --format s16ne \
+            --rate 22050 --latency-msec 500
+
+The child process receives the following additional environment variables which describe the message:
+
+  SAMEDEC_RATE="22050" (configured sample --rate)
+  SAMEDEC_MSG="ZCZC-EAS-RWT-012057-012081+0030-2780415-WTSP/TV-"
+  SAMEDEC_ORG="EAS" (or CIV,NWS,PEP)
+  SAMEDEC_ORIGINATOR="EAS Participant"
+  SAMEDEC_EVT="RWT"
+  SAMEDEC_EVENT="Required Weekly Test"
+  SAMEDEC_SIGNIFICANCE="T" (or M,S,E,A,W)
+  SAMEDEC_LOCATIONS="012057 012081"
+  SAMEDEC_ISSUETIME="1616883240" (UTC UNIX timestamp)
+  SAMEDEC_PURGETIME="1616886840" (UTC UNIX timestamp)
+
+Child processes MUST read or close standard input.
+Child processes MUST exit when their standard input is closed.
+
+ALWAYS TEST YOUR DECODING SETUP!
+"#;
+
+const ADVANCED: &str = "Advanced Modem Options";
+
+/// Top-level program arguments
+#[derive(Parser, Clone, Debug)]
+#[command(author = "Colin S. <https://github.com/cbs228/sameold>")]
+#[command(version)]
+#[command(about, long_about = None)]
+#[command(after_help = USAGE_SHORT, after_long_help = USAGE_LONG)]
+#[command(max_term_width = 100)]
+pub struct Args {
+    /// Verbosity level (-vvv for more)
+    #[arg(short, long, default_value_t = 0, action = clap::ArgAction::Count)]
+    pub verbose: u8,
+
+    /// Print NOTHING, not even SAME headers
+    #[arg(short, long)]
+    pub quiet: bool,
+
+    /// Sampling rate (Hz)
+    ///
+    /// Set to the sampling rate of your audio source. If sampling from
+    /// a sound card, use the card's native rate—usually 44100 or 48000.
+    /// Avoid resampling the audio.
+    #[arg(short, long, default_value_t = 22050)]
+    pub rate: u32,
+
+    /// Input file (or "-" for stdin)
+    ///
+    /// The input must be one-channel (mono), signed 16-bit
+    /// native-endian at --rate.
+    #[arg(long, default_value_t = STDIN_FILE.to_string())]
+    pub file: String,
+
+    /// Issue demo warning (DMO) and exit
+    ///
+    /// You must still provide an audio file, but you may use /dev/zero.
+    /// samedec will print a demo warning, invoke the CHILD process with
+    /// eight seconds of audio, and then exit.
+    #[arg(long)]
+    pub demo: bool,
+
+    /// DC-blocker filter length (fsym)
+    #[arg(long, default_value_t = 0.38)]
+    #[arg(hide_short_help = true)]
+    #[arg(help_heading = ADVANCED)]
+    pub dc_blocker_len: f32,
+
+    /// AGC bandwidth (fsym)
+    #[arg(long, default_value_t = 0.01)]
+    #[arg(hide_short_help = true)]
+    #[arg(help_heading = ADVANCED)]
+    pub agc_bw: f32,
+
+    /// Symbol timing loop bandwidth, searching (fsym)
+    #[arg(long, default_value_t = 0.125)]
+    #[arg(hide_short_help = true)]
+    #[arg(help_heading = ADVANCED)]
+    pub timing_bw_unlocked: f32,
+
+    /// Symbol timing loop bandwidth, tracking (fsym)
+    #[arg(long, default_value_t = 0.05)]
+    #[arg(hide_short_help = true)]
+    #[arg(help_heading = ADVANCED)]
+    pub timing_bw_locked: f32,
+
+    /// Symbol timing maximum deviation (fsym)
+    #[arg(long, default_value_t = 0.01)]
+    #[arg(hide_short_help = true)]
+    #[arg(help_heading = ADVANCED)]
+    pub timing_max_dev: f32,
+
+    /// Power req'd to start receiving (0.0 ≤ PWR ≤ 1.0)
+    #[arg(long, default_value_t = 0.10)]
+    #[arg(hide_short_help = true)]
+    #[arg(help_heading = ADVANCED)]
+    pub squelch_pwr_open: f32,
+
+    /// Power req'd to keep receiving (0.0 ≤ PWR ≤ 1.0)
+    #[arg(long, default_value_t = 0.05)]
+    #[arg(hide_short_help = true)]
+    #[arg(help_heading = ADVANCED)]
+    pub squelch_pwr_close: f32,
+
+    /// Permitted bit errors in sync pattern (<7)
+    #[arg(long, default_value_t = 2)]
+    #[arg(value_parser = value_parser!(u32).range(0..6))]
+    #[arg(hide_short_help = true)]
+    #[arg(help_heading = ADVANCED)]
+    pub preamble_max_errors: u32,
+
+    /// Spawn child process to handle message audio. Optional.
+    ///
+    /// Arguments are provided VERBATIM to the child process
+    /// without shell interpretation.
+    #[arg(last = true)]
+    pub child: Vec<String>,
+}
+
+impl Args {
+    /// Return true if the user requests input from stdin
+    pub fn input_is_stdin(&self) -> bool {
+        self.file == STDIN_FILE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_clap() {
+        use clap::CommandFactory;
+        Args::command().debug_assert();
+    }
+}

--- a/crates/samedec/src/main.rs
+++ b/crates/samedec/src/main.rs
@@ -1,220 +1,41 @@
 use std::io;
 
 use byteorder::{NativeEndian, ReadBytesExt};
-use clap::{App, Arg, ArgMatches};
+use clap::Parser;
 use log::{info, LevelFilter};
 
 use sameold::SameReceiverBuilder;
 
 mod app;
+mod cli;
 mod spawner;
 
-const STDIN_FILE: &str = "-";
-
-const USAGE: &str = r#"
-A simple decoder for Specific Area Message Encoding (SAME). This
-program accepts raw PCM samples in signed 16-bit (i16) format,
-at the given sampling --rate, and decodes any SAME headers that
-are present. Decoded headers are printed in their ASCII
-representation.
-
-You can pipe in an audio file with sox
-
-    sox input.wav -t raw -r 22.5k -e signed -b 16 -c 1 - \
-        | samedec -r 22050
-
-Arguments which follow "--" will be used to spawn a child
-process. The child process will have the input audio signal
-piped to its standard input. You can use this to play or store
-SAME messages.
-
-    parec --channels 1 --format s16ne \
-      --rate 22050 --latency-msec 500 \
-        | samedec -r 22050 -- pacat \
-            --channels 1 --format s16ne \
-            --rate 22050 --latency-msec 500
-
-The child process receives the following additional environment
-variables which describe the message:
-
-  SAMEDEC_RATE="22050" (configured sample --rate)
-  SAMEDEC_MSG="ZCZC-EAS-RWT-012057-012081+0030-2780415-WTSP/TV-"
-  SAMEDEC_ORG="EAS" (or CIV,NWS,PEP)
-  SAMEDEC_ORIGINATOR="EAS Participant"
-  SAMEDEC_EVT="RWT"
-  SAMEDEC_EVENT="Required Weekly Test"
-  SAMEDEC_SIGNIFICANCE="T" (or M,S,E,A,W)
-  SAMEDEC_LOCATIONS="012057 012081"
-  SAMEDEC_ISSUETIME="1616883240" (UTC UNIX timestamp)
-  SAMEDEC_PURGETIME="1616886840" (UTC UNIX timestamp)
-
-Child processes MUST read or close standard input.
-Child processes MUST exit when their standard input is closed.
-
-ALWAYS TEST YOUR DECODING SETUP!
-"#;
+use cli::Args;
 
 fn main() {
-    let matches = App::new(env!("CARGO_PKG_NAME"))
-        .version(env!("CARGO_PKG_VERSION"))
-        .author("Colin S. <https://crates.io/crates/samedec>")
-        .about("SAME/EAS decoder")
-        .after_help(USAGE)
-        .arg(
-            Arg::with_name("v")
-                .long("verbose")
-                .short("v")
-                .multiple(true)
-                .help("Verbosity level (-vvv for more)")
-                .display_order(1),
-        )
-        .arg(
-            Arg::with_name("quiet")
-                .long("quiet")
-                .short("q")
-                .help("Print NOTHING, not even SAME headers")
-                .display_order(2),
-        )
-        .arg(
-            Arg::with_name("rate")
-                .long("rate")
-                .short("r")
-                .takes_value(true)
-                .default_value("22050")
-                .help("Sampling rate (Hz)")
-                .display_order(3),
-        )
-        .arg(
-            Arg::with_name("file")
-                .long("file")
-                .help("Input file (or \"-\" for stdin)")
-                .required(false)
-                .takes_value(true)
-                .default_value(STDIN_FILE),
-        )
-        .arg(
-            Arg::with_name("demo")
-                .long("demo")
-                .takes_value(false)
-                .help("Issue demo warning (DMO) and exit"),
-        )
-        .arg(
-            Arg::with_name("dc-blocker-len")
-                .long("dc-blocker-len")
-                .help("DC Blocker filter length (fsym)")
-                .takes_value(true)
-                .default_value("0.38")
-                .hidden_short_help(true),
-        )
-        .arg(
-            Arg::with_name("agc-bw")
-                .long("agc-bw")
-                .help("AGC bandwidth (fsym)")
-                .takes_value(true)
-                .default_value("0.01")
-                .hidden_short_help(true),
-        )
-        .arg(
-            Arg::with_name("timing-bw-unlocked")
-                .long("timing-bw-unlocked")
-                .help("Timing loop bandwidth, searching (fsym)")
-                .takes_value(true)
-                .default_value("0.125")
-                .hidden_short_help(true),
-        )
-        .arg(
-            Arg::with_name("timing-bw-locked")
-                .long("timing-bw-locked")
-                .help("Timing loop bandwidth, tracking (fsym)")
-                .takes_value(true)
-                .default_value("0.05")
-                .hidden_short_help(true),
-        )
-        .arg(
-            Arg::with_name("timing-max-dev")
-                .long("timing-max-dev")
-                .help("Timing maximum deviation (fsym)")
-                .takes_value(true)
-                .default_value("0.01")
-                .hidden_short_help(true),
-        )
-        .arg(
-            Arg::with_name("squelch-pwr-open")
-                .long("squelch-pwr-open")
-                .help("Power req'd to start receiving (0.0 ≤ PWR ≤ 1.0)")
-                .takes_value(true)
-                .default_value("0.10")
-                .hidden_short_help(true),
-        )
-        .arg(
-            Arg::with_name("squelch-pwr-close")
-                .long("squelch-pwr-close")
-                .help("Power req'd to keep receiving (0.0 ≤ PWR ≤ 1.0)")
-                .takes_value(true)
-                .default_value("0.05")
-                .hidden_short_help(true),
-        )
-        .arg(
-            Arg::with_name("preamble-max-errors")
-                .long("preamble-max-errors")
-                .help("Permitted bit errors in sync pattern (<7)")
-                .takes_value(true)
-                .default_value("2")
-                .hidden_short_help(true),
-        )
-        .arg(
-            Arg::with_name("CHILD")
-                .takes_value(true)
-                .multiple(true)
-                .last(true)
-                .help("Spawn child process to handle message audio."),
-        )
-        .get_matches();
-
-    log_setup(&matches);
+    // Parse options and start logging
+    let args = Args::parse();
+    log_setup(&args);
 
     // create the decoder
-    let rate = str::parse::<u32>(matches.value_of("rate").unwrap())
-        .expect("invalid sampling --rate: expect integer");
-    let mut rx = SameReceiverBuilder::new(rate)
+    let mut rx = SameReceiverBuilder::new(args.rate)
         .with_agc_gain_limits(1.0f32 / (i16::MAX as f32), 1.0 / 200.0)
-        .with_agc_bandwidth(
-            str::parse(matches.value_of("agc-bw").unwrap()).expect("--agc-bw: expect float"),
-        )
-        .with_dc_blocker_length(
-            str::parse(matches.value_of("dc-blocker-len").unwrap())
-                .expect("--dc-blocker-len: expect float"),
-        )
-        .with_timing_bandwidth(
-            str::parse(matches.value_of("timing-bw-unlocked").unwrap())
-                .expect("--timing-bw-unlocked: expect float"),
-            str::parse(matches.value_of("timing-bw-locked").unwrap())
-                .expect("--timing-bw-locked: expect float"),
-        )
-        .with_timing_max_deviation(
-            str::parse(matches.value_of("timing-max-dev").unwrap())
-                .expect("--timing-max-dev: expect float"),
-        )
-        .with_squelch_power(
-            str::parse(matches.value_of("squelch-pwr-open").unwrap())
-                .expect("--squelch-pwr-open: expect float"),
-            str::parse(matches.value_of("squelch-pwr-close").unwrap())
-                .expect("--squelch-pwr-close: expect float"),
-        )
-        .with_preamble_max_errors(
-            str::parse(matches.value_of("preamble-max-errors").unwrap())
-                .expect("--preamble-max-errors: expect integer"),
-        )
+        .with_agc_bandwidth(args.agc_bw)
+        .with_dc_blocker_length(args.dc_blocker_len)
+        .with_timing_bandwidth(args.timing_bw_unlocked, args.timing_bw_locked)
+        .with_timing_max_deviation(args.timing_max_dev)
+        .with_squelch_power(args.squelch_pwr_open, args.squelch_pwr_close)
+        .with_preamble_max_errors(args.preamble_max_errors)
         .build();
 
     // file setup: locks stdin in case we need it
     let stdin = io::stdin();
     let stdin_handle = stdin.lock();
-    let mut inbuf = file_setup(&matches, stdin_handle);
+    let mut inbuf = file_setup(&args, stdin_handle);
 
     // processing: read i16 from the input source
     app::run(
-        &matches,
+        &args,
         &mut rx,
         std::iter::from_fn(|| Some(inbuf.read_i16::<NativeEndian>().ok()?)),
     );
@@ -222,7 +43,7 @@ fn main() {
     // flush all data samples out of the decoder
     match rx.flush() {
         Some(lastmsg) => {
-            if matches.occurrences_of("quiet") == 0 {
+            if !args.quiet {
                 println!("{}", lastmsg)
             }
         }
@@ -230,13 +51,13 @@ fn main() {
     }
 }
 
-fn log_setup(args: &ArgMatches) {
-    if args.occurrences_of("quiet") > 0 {
+fn log_setup(args: &Args) {
+    if args.quiet {
         // no logging
         return;
     } else if std::env::var_os("RUST_LOG").is_none() {
         // parameter controls
-        let log_filter = match args.occurrences_of("v") {
+        let log_filter = match args.verbose {
             0 => LevelFilter::Warn,
             1 => LevelFilter::Info,
             2 => LevelFilter::Debug,
@@ -254,17 +75,16 @@ fn log_setup(args: &ArgMatches) {
 }
 
 fn file_setup<'stdin>(
-    args: &ArgMatches,
+    args: &Args,
     stdin: std::io::StdinLock<'stdin>,
 ) -> Box<dyn io::BufRead + 'stdin> {
-    let filename = args.value_of("file").unwrap();
-    if filename == STDIN_FILE {
+    if args.input_is_stdin() {
         info!("SAME decoder reading standard input");
         Box::new(io::BufReader::new(stdin))
     } else {
         info!("SAME decoder reading file");
         Box::new(io::BufReader::new(
-            std::fs::File::open(filename).expect("Unable to open requested FILE"),
+            std::fs::File::open(&args.file).expect("Unable to open requested FILE"),
         ))
     }
 }


### PR DESCRIPTION
Improve error reporting for common mistakes, such as specifying a non-existent file or for trying to use standard input via a pty.

Update to clap 4.1 which offers better macros and an improved `--help` output.

The input arguments themselves are unchanged.