### PR TITLE
ci: update docker action versions

### DIFF
--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -60,6 +60,9 @@ jobs:
 
     needs: vendor_sources
 
+    # qemu cross-compiling is very slow
+    timeout-minutes: 60
+
     env:
       # See <https://hub.docker.com/_/rust> for list of tags
       BUILD_RUST_TAG: 1.70.0
@@ -109,12 +112,12 @@ jobs:
         sudo systemctl restart docker
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
       with:
         platforms: all
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v3
 
     - name: Prepare output directory
       run: |
@@ -126,7 +129,7 @@ jobs:
       # install/bin/samedec-x86_64-unknown-linux-gnu
       # and the like.
     - name: Build
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v5
       with:
         context: .
         push: false


### PR DESCRIPTION
Update the release CI to use the latest versions of qemu, buildx, and docker.