### PR TITLE
samedec: flush on EOF in main app

### DIFF
--- a/crates/samedec/src/app.rs
+++ b/crates/samedec/src/app.rs
@@ -114,7 +114,8 @@ impl State<Waiting> {
             return Some(msg.into());
         }
 
-        None
+        // end of file; flush any remaining messages out of the decoder
+        Some(receiver.flush()?.into())
     }
 }
 

--- a/crates/samedec/src/main.rs
+++ b/crates/samedec/src/main.rs
@@ -48,16 +48,6 @@ fn samedec() -> Result<(), CliError> {
         std::iter::from_fn(|| Some(inbuf.read_i16::<NativeEndian>().ok()?)),
     );
 
-    // flush all data samples out of the decoder
-    match rx.flush() {
-        Some(lastmsg) => {
-            if !args.quiet {
-                println!("{}", lastmsg)
-            }
-        }
-        None => {}
-    }
-
     Ok(())
 }
 


### PR DESCRIPTION
Previously, `samedec::app::run()` would unceremoniously exit on EOF. Since an EOF results in samples being "stranded" in filter buffers and other parts of the system, it is necessary to push zeros through the system to make it output any remaining Messages.

This "flush" operation was performed by isolated code that ran after the app terminated. This would print the Message(s), but it would not take any other actions like spawning child processes.

We should spawn the child even if there's no audio data that follows. The state machine will simply `wait()` for it to terminate and then exit.

This change permits us to run child processes on short snippets of SAME data—i.e., our `sample/*.bin` data files.

This is CLI-expanding behavior.