### PR TITLE
sameold,samedec: drop SignificanceLevel::Message

### DIFF
--- a/crates/samedec/README.md
+++ b/crates/samedec/README.md
@@ -283,7 +283,6 @@ The child process receives the following additional environment variables:
   the event code is unknown).
 
   * `T`: Test
-  * `M`: Message
   * `S`: Statement
   * `E`: Emergency
   * `A`: Watch

--- a/crates/sameold/src/message/significance.rs
+++ b/crates/sameold/src/message/significance.rs
@@ -15,7 +15,6 @@ use strum::EnumMessage;
 /// | Code    | Significance                                      |
 /// |---------|---------------------------------------------------|
 /// | `xxT`   | [test](crate::SignificanceLevel::Test)            |
-/// | `xxM`   | [message](crate::SignificanceLevel::Message)      |
 /// | `xxS`   | [statement](crate::SignificanceLevel::Statement)  |
 /// | `xxE`   | [emergency](crate::SignificanceLevel::Emergency)  |
 /// | `xxA`   | [watch](crate::SignificanceLevel::Watch)          |
@@ -79,12 +78,6 @@ pub enum SignificanceLevel {
     /// A message intended only for testing purposes. "This is only a test."
     #[strum(serialize = "T", detailed_message = "Test")]
     Test,
-
-    /// Message
-    ///
-    /// A non-emergency message
-    #[strum(serialize = "M", detailed_message = "Message")]
-    Message,
 
     /// Statement
     ///


### PR DESCRIPTION
The `SignificanceLevel::Message` is not part of NWSI 10-1712 or any other known standard, and very few event codes in sameold ever implement it.

Discontinue this enum variant.

The following event codes are affected and are upgraded to `Statement`s:

* ADR Administrative Message
* NMN Network Message Notification

This is an API-BREAKING change. The samedec CLI is unaffected, but it is removed from the documentation.