### PR TITLE
ci: migrate MacOS builds to aarch64-apple-darwin

### DIFF
--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -272,12 +272,12 @@ jobs:
     needs: vendor_sources
 
     env:
-      CARGO_BUILD_TARGET: x86_64-apple-darwin
+      CARGO_BUILD_TARGET: aarch64-apple-darwin
       CARGO_NET_OFFLINE: "true"
       CARGO_INSTALL_ROOT: "install/"
       RUSTFLAGS: '-C strip=symbols'
       samedec_exe: 'install/bin/samedec'
-      samedec_target_exe: install/bin/samedec-x86_64-apple-darwin
+      samedec_target_exe: install/bin/samedec-aarch64-apple-darwin
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The Github Actions runners are aarch64, so that is what we will use going forward. Fixes release job failure.