### PR TITLE
ci: containerize the environment, more checks

### DIFF
--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -1,0 +1,94 @@
+#
+# Debian base image
+#
+
+ARG DEBIAN_SUITE=buster
+
+FROM docker.io/library/debian:${DEBIAN_SUITE}-slim
+
+# Create a non-root user for running builds
+# GHA wants uid 1001
+ARG UID=1001
+
+RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
+    --mount=target=/var/cache/apt,type=cache,sharing=locked \
+    set -eux; \
+    # create an unprivileged user for builds
+    useradd -u "$UID" --create-home --user-group builder; \
+    # fixed build directories
+    mkdir -m 750 /src /target /install /install/bin; \
+    chown builder:builder /src /target /install /install/bin; \
+    # re-enable apt caching (we have a cache mount)
+    rm -f /etc/apt/apt.conf.d/docker-clean; \
+    # enable packages from multiple architectures
+    dpkg --add-architecture amd64; \
+    dpkg --add-architecture armhf; \
+    dpkg --add-architecture arm64; \
+    dpkg --add-architecture i386; \
+    # install native C compilers, CI utilities, and qemu
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        gcc \
+        git \
+        libc6-dev \
+        qemu-user \
+        qemu-user-binfmt \
+        tar \
+        zstd \
+    ;
+
+# Directories for Rust sources and installed binaries
+VOLUME ["/src", "/install"]
+
+# Install rustup and platform-native target
+#
+#    RUST_VERSIONS: list of version numbers or strings
+#                   like `stable`. The first entry becomes the
+#                   default toolchain version.
+#
+#      RUSTUP_ARCH: native architecture as llvm platform triple
+#
+#   RUSTUP_VERSION: version of rustup to download
+#
+#    RUSTUP_SHA256: checksum for this version of rustup on
+#                   ${RUST_ARCH}.
+#
+# Default values are provided only for x86_64.
+ARG RUST_VERSIONS="stable" \
+    RUSTUP_ARCH="x86_64-unknown-linux-gnu" \
+    RUSTUP_VERSION="1.27.1" \
+    RUSTUP_SHA256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" \
+    RUSTUP_URL=""
+
+# Basic cargo/rust configuration, including a `cargo install`
+# location of `/install`.
+ENV PATH=/install/bin:/usr/local/cargo/bin:$PATH \
+    CARGO_INSTALL_ROOT=/install \
+    CARGO_TARGET_DIR=/target \
+    CARGO_TERM_COLOR=always \
+    RUST_BACKTRACE=1 \
+    RUSTUP_HOME=/usr/local/rustup
+
+# Instructions adapted from official Docker image
+# <https://github.com/rust-lang/docker-rust/blob/master/Dockerfile-slim.template>
+RUN set -eux; \
+    export CARGO_HOME=/usr/local/cargo; \
+    [ -n "${RUSTUP_URL:-}" ] || RUSTUP_URL="https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUSTUP_ARCH}/rustup-init"; \
+    curl -O -sSf "$RUSTUP_URL"; \
+    echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    default_rust="$(echo "$RUST_VERSIONS" | cut -f1 -d' ')"; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain "$default_rust"; \
+    rm rustup-init; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version; \
+    rustup set auto-self-update disable; \
+    echo "$RUST_VERSIONS" | xargs rustup toolchain add --profile minimal; \
+    (umask 022 && echo "$RUSTUP_ARCH" >/etc/rust-native-arch)
+
+# Install scripts
+COPY rootfiles/ /

--- a/.github/container/Dockerfile.rust.aarch64-unknown-linux-gnu
+++ b/.github/container/Dockerfile.rust.aarch64-unknown-linux-gnu
@@ -1,0 +1,32 @@
+#
+# Debian base image, with arm64 toolchains
+#
+
+FROM ghcr.io/cbs228/sameold/builder.base:latest
+
+RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
+    --mount=target=/var/cache/apt,type=cache,sharing=locked \
+    [ "$(dpkg --print-architecture)" != arm64 ] || exit 0; \
+    set -eux; \
+    apt-get update; \
+    apt-get install -y \
+        binutils-aarch64-linux-gnu \
+        gcc-aarch64-linux-gnu \
+        libc6-dev-arm64-cross \
+        libc6:arm64 \
+    ;
+
+ARG RUST_TARGET="aarch64-unknown-linux-gnu"
+
+RUN set -eux; \
+    export CARGO_HOME=/usr/local/cargo; \
+    rustup target add "$RUST_TARGET";
+
+ENV CARGO_BUILD_TARGET="$RUST_TARGET" \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER=qemu-run-maybe
+
+USER builder
+
+LABEL org.opencontainers.image.source="https://github.com/cbs228/sameold"
+LABEL org.opencontainers.image.description="Linux cross-compiling Rust environment for sameold and samedec."

--- a/.github/container/Dockerfile.rust.armv7-unknown-linux-gnueabihf
+++ b/.github/container/Dockerfile.rust.armv7-unknown-linux-gnueabihf
@@ -1,0 +1,32 @@
+#
+# Debian base image, with armhf toolchains
+#
+
+FROM ghcr.io/cbs228/sameold/builder.base:latest
+
+RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
+    --mount=target=/var/cache/apt,type=cache,sharing=locked \
+    [ "$(dpkg --print-architecture)" != armhf ] || exit 0; \
+    set -eux; \
+    apt-get update; \
+    apt-get install -y \
+        binutils-arm-linux-gnueabi \
+        gcc-arm-linux-gnueabihf \
+        libc6-dev-armhf-cross \
+        libc6:armhf \
+    ;
+
+ARG RUST_TARGET="armv7-unknown-linux-gnueabihf"
+
+RUN set -eux; \
+    export CARGO_HOME=/usr/local/cargo; \
+    rustup target add "$RUST_TARGET";
+
+ENV CARGO_BUILD_TARGET="$RUST_TARGET" \
+    CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
+    CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_RUNNER=qemu-run-maybe
+
+USER builder
+
+LABEL org.opencontainers.image.source="https://github.com/cbs228/sameold"
+LABEL org.opencontainers.image.description="Linux cross-compiling Rust environment for sameold and samedec."

--- a/.github/container/Dockerfile.rust.i686-unknown-linux-gnu
+++ b/.github/container/Dockerfile.rust.i686-unknown-linux-gnu
@@ -1,0 +1,32 @@
+#
+# Debian base image, with i386 toolchains
+#
+
+FROM ghcr.io/cbs228/sameold/builder.base:latest
+
+RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
+    --mount=target=/var/cache/apt,type=cache,sharing=locked \
+    [ "$(dpkg --print-architecture)" != i386 ] || exit 0; \
+    set -eux; \
+    apt-get update; \
+    apt-get install -y \
+        binutils-i686-linux-gnu \
+        gcc-i686-linux-gnu \
+        libc6-dev-i386-cross \
+        libc6:i386 \
+    ;
+
+ARG RUST_TARGET="i686-unknown-linux-gnu"
+
+RUN set -eux; \
+    export CARGO_HOME=/usr/local/cargo; \
+    rustup target add "$RUST_TARGET";
+
+ENV CARGO_BUILD_TARGET="$RUST_TARGET" \
+    CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER=i686-linux-gnu-gcc \
+    CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_RUNNER=qemu-run-maybe
+
+USER builder
+
+LABEL org.opencontainers.image.source="https://github.com/cbs228/sameold"
+LABEL org.opencontainers.image.description="Linux cross-compiling Rust environment for sameold and samedec."

--- a/.github/container/Dockerfile.rust.x86_64-unknown-linux-gnu
+++ b/.github/container/Dockerfile.rust.x86_64-unknown-linux-gnu
@@ -1,0 +1,32 @@
+#
+# Debian base image, with amd64 toolchains
+#
+
+FROM ghcr.io/cbs228/sameold/builder.base:latest
+
+RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
+    --mount=target=/var/cache/apt,type=cache,sharing=locked \
+    [ "$(dpkg --print-architecture)" != amd64 ] || exit 0; \
+    set -eux; \
+    apt-get update; \
+    apt-get install -y \
+        binutils-x86-64-linux-gnu \
+        gcc-x86-64-linux-gnu \
+        libc6-dev-amd64-cross \
+        libc6:amd64 \
+    ;
+
+ARG RUST_TARGET="x86_64-unknown-linux-gnu"
+
+RUN set -eux; \
+    export CARGO_HOME=/usr/local/cargo; \
+    rustup target add "$RUST_TARGET";
+
+ENV CARGO_BUILD_TARGET="$RUST_TARGET" \
+    CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc \
+    CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER=qemu-run-maybe
+
+USER builder
+
+LABEL org.opencontainers.image.source="https://github.com/cbs228/sameold"
+LABEL org.opencontainers.image.description="Linux cross-compiling Rust environment for sameold and samedec."

--- a/.github/container/build.sh
+++ b/.github/container/build.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# (re)build the CI container image
+
+set -euo pipefail
+
+now="$(date -u +'%Y-%m-%d')"
+
+CONTAINER_PREFIX="ghcr.io/cbs228"
+CONTAINER_FQNAME="${CONTAINER_PREFIX}/sameold/builder/%s"
+CONTAINER_TAGS=("$now" "latest")
+
+RUST_VERSIONS=("1.84.0")
+
+usage() {
+  cat <<EOF
+Usage: $0 [--push]
+
+Build container images for the CI environment
+EOF
+}
+
+container_name() {
+  # Usage: container_name SUFFIX
+
+  #shellcheck disable=SC2059
+  printf "$CONTAINER_FQNAME" "$1"
+}
+
+run() {
+  # Echo and run
+  echo >&2 "$@"
+  "$@"
+}
+
+if ! options="$(getopt -o 'hp' --long help,push -- "$@")"; then
+  usage >&2
+  exit 1
+fi
+
+eval set -- "${options:-}"
+push_images=''
+while true; do
+  case "${1:-}" in
+    (-h | --help)
+      usage
+      exit 0 ;;
+    (-p | --push)
+      push_images=y ;;
+    ('') ;;
+  esac
+  shift || break
+done
+
+selfdir="$(dirname "${0?}")"
+
+[ -z "${push_images:-}" ] || \
+  podman login --authfile="${HOME}/.docker/config.json" "$CONTAINER_PREFIX"
+
+# build the base image
+base_tag="$(container_name base):latest"
+
+run podman build \
+  -f "${selfdir?}/Dockerfile.base" \
+  --build-arg RUST_VERSIONS="${RUST_VERSIONS[*]}" \
+  --tag "$base_tag" \
+  "${selfdir?}"
+
+# build architecture-specific images
+for containerfile in "${selfdir}/"Dockerfile.rust.*; do
+  platform_triple="${containerfile##*.}"
+  cur_tag="$(container_name "$platform_triple"):${CONTAINER_TAGS[0]}"
+
+  run podman build \
+    --from "$base_tag" \
+    -f "${containerfile}" \
+    --tag "${cur_tag}" \
+    "${selfdir?}"
+done
+
+# if all builds succeed, apply remaining tags and push
+for containerfile in "${selfdir}/"Dockerfile.rust.*; do
+  platform_triple="${containerfile##*.}"
+  cur_base_name="$(container_name "$platform_triple")"
+
+  run podman tag "${CONTAINER_TAGS[@]/#/"$cur_base_name:"}"
+
+  if [ -n "${push_images:-}" ]; then
+    for t in "${CONTAINER_TAGS[@]}"; do
+      run podman push "$cur_base_name:$t"
+    done
+  fi
+done

--- a/.github/container/rootfiles/usr/local/bin/qemu-run-maybe
+++ b/.github/container/rootfiles/usr/local/bin/qemu-run-maybe
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# Runs a Rust binary in qemu user-mode emulation if required.
+#
+# Not all containerized runtime environments are created
+# equal. Some have binfmt configured so that everything
+# Just Works. Others do not. This script manually maps
+# various Linux Rust triples to their qemu equivalents.
+
+program="${1?missing PROGRAM}"
+shift || true
+
+if [ ! -x "$program" ]; then
+  program="$(command -v "$program")"
+fi
+
+case "${CARGO_BUILD_TARGET:-}" in
+  ("$(cat /etc/rust-native-arch)")
+    # the build target is the native architecture
+    exec "$program" "$@"
+    ;;
+  (aarch64-unknown-linux-*)
+    exec qemu-aarch64 -- "$program" "$@"
+    ;;
+  (armv7-unknown-linux-*eabihf)
+    exec qemu-arm -- "$program" "$@"
+    ;;
+  (i686-unknown-linux-*)
+    exec qemu-i386 -- "$program" "$@"
+    ;;
+  (x86_64-unknown-linux-*)
+    exec qemu-x86_64 -- "$program" "$@"
+    ;;
+  ('')
+    # unset; assume native
+    exec "$program" "$@"
+    ;;
+  (*)
+    echo >&2 "FATAL: Unknown CARGO_BUILD_TARGET=${CARGO_BUILD_TARGET}"
+    exit 101;
+  ;;
+esac

--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -60,38 +60,23 @@ jobs:
 
     needs: vendor_sources
 
-    # qemu cross-compiling is very slow
-    timeout-minutes: 60
-
-    env:
-      # See <https://hub.docker.com/_/rust> for list of tags
-      BUILD_RUST_TAG: 1.70.0
-      BUILD_OS_GNU: slim-buster
-      BUILD_OS_MUSL: alpine
-      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
-
     strategy:
       matrix:
         include:
-          - docker: linux/amd64
-            os: slim-buster
-            rust: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-gnu
+          - target: aarch64-unknown-linux-gnu
+          - target: armv7-unknown-linux-gnueabihf
+          - target: i686-unknown-linux-gnu
 
-          - docker: linux/amd64
-            os: alpine
-            rust: x86_64-unknown-linux-musl
-
-          - docker: linux/arm64
-            os: slim-buster
-            rust: aarch64-unknown-linux-gnu
-
-          - docker: linux/arm64
-            os: alpine
-            rust: aarch64-unknown-linux-musl
-
-          - docker: linux/arm/v7
-            os: slim-buster
-            rust: armv7-unknown-linux-gnueabihf
+    container:
+      image: ghcr.io/cbs228/sameold/builder/${{ matrix.target }}:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      env:
+        CARGO_NET_OFFLINE: "true"
+        CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+        RUSTFLAGS: '-C strip=symbols'
 
     steps:
     - uses: actions/checkout@v3
@@ -106,55 +91,26 @@ jobs:
         enableCrossOsArchive: true
         fail-on-cache-miss: true
 
-    - name: Set swap space
-      uses: pierotofy/set-swap-space@v1.0
-      with:
-        swap-size-gb: 10
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-      with:
-        platforms: all
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Prepare output directory
+    - name: Cross-compile, cross-test, and install
       run: |
-        mkdir -m 700 -p "install/bin"
+        cargo test --offline --frozen --release --workspace &&
+        cargo install --offline --frozen --path=crates/samedec
 
-      # Builds a special target in our Dockerfile which builds
-      # an empty image containing only our Rust binary. This task
-      # exports the file to
-      # install/bin/samedec-x86_64-unknown-linux-gnu
-      # and the like.
-    - name: Build
-      uses: docker/build-push-action@v5
-      with:
-        context: .
-        push: false
-        load: false
-        cache-from: type=gha,scope=${{ matrix.os }}_${{ matrix.rust }}
-        cache-to: type=gha,mode=max,scope=${{ matrix.os }}_${{ matrix.rust }}
-        tags: samedec:latest
-        target: localfile
-        build-args: |
-          CARGO_BUILD_TARGET=${{ matrix.rust }}
-          CARGO_NET_OFFLINE=true
-          BUILD_OS_TAG=${{ matrix.os }}
-          BUILD_RUST_TAG=${{ env.BUILD_RUST_TAG }}
-        platforms: ${{ matrix.docker }}
-        outputs: "type=local,dest=install/bin"
+    - name: Run integration tests on release-mode build
+      run: |
+        qemu-run-maybe samedec --version &&
+        cd sample &&
+        ./test.sh qemu-run-maybe samedec
 
     - name: Copy artifact
       run: |
-        cp install/bin/samedec install/bin/samedec-${{ matrix.rust }}
+        cp /install/bin/samedec /install/bin/samedec-${{ matrix.target }}
 
     - name: Store artifact
       uses: actions/upload-artifact@v3
       with:
-        name: samedec-${{ matrix.rust }}
-        path: install/bin/samedec-${{ matrix.rust }}
+        name: samedec-${{ matrix.target }}
+        path: /install/bin/samedec-${{ matrix.target }}
         retention-days: 3
 
     - name: Upload tagged release
@@ -162,7 +118,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/samedec-')
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: install/bin/samedec-${{ matrix.rust }}
+        file: /install/bin/samedec-${{ matrix.target }}
         overwrite: true
 
     - name: Update tag for nightly release
@@ -181,7 +137,7 @@ jobs:
         release_name: "Nightly Release"
         body: "This is a rolling release built from the latest `develop` branch."
         prerelease: true
-        file: install/bin/samedec-${{ matrix.rust }}
+        file: /install/bin/samedec-${{ matrix.target }}
         overwrite: true
 
   # Win32 build, on whatever machine github has available

--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       name: Update crate cargo-vendor cache
       id: vendor_cache
       with:
@@ -33,7 +33,7 @@ jobs:
           cargo-vendor
         enableCrossOsArchive: true
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       name: Update cargo registry cache
       if: steps.vendor_cache.outputs.cache-hit != 'true'
       with:
@@ -96,7 +96,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: actions/cache/restore@v3
+    - uses: actions/cache/restore@v4
       name: Restore crate cargo-vendor cache
       with:
         path: |
@@ -205,7 +205,7 @@ jobs:
       shell: bash
       run: cargo version
 
-    - uses: actions/cache/restore@v3
+    - uses: actions/cache/restore@v4
       name: Restore crate cargo-vendor cache
       with:
         path: |
@@ -285,7 +285,7 @@ jobs:
     - name: Record environment
       run: cargo version
 
-    - uses: actions/cache/restore@v3
+    - uses: actions/cache/restore@v4
       name: Restore crate cargo-vendor cache
       with:
         path: |

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -168,3 +168,39 @@ jobs:
         pushd sample
         ./test.sh
         popd
+
+  # Linux builds within our containerized release environment
+  test_samedec_containerized:
+    runs-on: ubuntu-latest
+
+    needs: vendor_sources
+
+    container:
+      image: ghcr.io/cbs228/sameold/builder/x86_64-unknown-linux-gnu:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      env:
+        CARGO_NET_OFFLINE: "true"
+        CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions/cache/restore@v4
+      name: Restore crate cargo-vendor cache
+      with:
+        path: |
+          .cargo
+          vendor
+        key: cargo-vendor-${{ hashFiles('**/Cargo.lock') }}
+        enableCrossOsArchive: true
+        fail-on-cache-miss: true
+
+    - name: Cross-compile and cross-test
+      run: cargo test --frozen --verbose
+
+    - name: Run integration tests on debug-mode build
+      run: |
+        cargo run -p samedec -- --version &&
+        cd sample && ./test.sh

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       name: Update crate cargo-vendor cache
       id: vendor_cache
       with:
@@ -30,7 +30,7 @@ jobs:
           cargo-vendor
         enableCrossOsArchive: true
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       name: Update cargo registry cache
       if: steps.vendor_cache.outputs.cache-hit != 'true'
       with:
@@ -70,7 +70,7 @@ jobs:
       shell: bash
       run: cargo version
 
-    - uses: actions/cache/restore@v3
+    - uses: actions/cache/restore@v4
       name: Restore crate cargo-vendor cache
       with:
         path: |
@@ -104,7 +104,7 @@ jobs:
       shell: bash
       run: cargo version
 
-    - uses: actions/cache/restore@v3
+    - uses: actions/cache/restore@v4
       name: Restore crate cargo-vendor cache
       with:
         path: |

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -11,6 +11,45 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  # lints
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Checking for whitespace errors (PRs only)
+      if: github.event.pull_request.base.sha
+      run: |
+        git diff --check "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}" || {
+          echo >&2 "Your pull request introduces whitespace errors,";
+          echo >&2 "which is not allowed. Please run:";
+          echo >&2;
+          echo >&2 "    git rebase --whitespace=fix";
+          echo >&2 "    git push -f";
+          echo >&2;
+          echo >&2 "to correct and resubmit.";
+          exit 1;
+        }
+
+    - name: Checking for cargo-fmt errors
+      run: |
+        cargo fmt --check || { \
+          echo >&2 "Your pull request does not conform to cargo-fmt";
+          echo >&2 "Rust format, which is not allowed. Please run:";
+          echo >&2;
+          echo >&2 "    cargo fmt";
+          echo >&2 "    git commit -a --amend";
+          echo >&2 "    git push -f";
+          echo >&2;
+          echo >&2 "to correct and resubmit. If \`cargo fmt\` touches";
+          echo >&2 "code which is not part of your MR, please let us";
+          echo >&2 "know in the comments.";
+          exit 1;
+        }
+
   # run `cargo vendor` and cache it
   vendor_sources:
     runs-on: ubuntu-latest
@@ -49,6 +88,10 @@ jobs:
         mkdir -p .cargo
         mkdir -p vendor
         cargo vendor --versioned-dirs --locked >.cargo/config.toml
+
+    - name: Check compiler lints
+      run: cargo check --workspace
+      continue-on-error: true
 
   test_sameold:
     strategy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,7 +105,7 @@ COPY sample sample
 
 RUN samedec --version && \
     cd sample && \
-    SAMEDEC=/usr/local/bin/samedec ./test.sh && \
+    ./test.sh /usr/local/bin/samedec && \
     cd ..
 
 ###


### PR DESCRIPTION
Add more CI checks for:

* Git whitespace errors
* cargo-fmt compliance
* cargo check output (warns only)

We also migrate the Linux release jobs to a container image,

    ghcr.io/cbs228/sameold/builder/${TARGET}

which has a build script and Dockerfiles available. The image relies on Debian's excellent multiarch and cross-compiler support to build for non-amd64 Debian architectures, including:

* armhf
* arm64
* i386

Previously, support for these architectures relied on running an entire foreign-architecture container, with a foreign-architecture Rust toolchain, in qemu. This was—predictably—both slow and unreliable. Build jobs usually timed out. Cross-compiling is much faster.

musl releases are discontinued for the time being. Our gnu builds continue to target glibc 2.28.

The `./test.sh` integration test script now takes the path or command to invoke `samedec` as regular CLI arguments.