### PR TITLE
ci: container image improvements

### DIFF
--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -15,9 +15,8 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     set -eux; \
     # create an unprivileged user for builds
     useradd -u "$UID" --create-home --user-group builder; \
-    # fixed build directories
-    mkdir -m 750 /src /target /install /install/bin; \
-    chown builder:builder /src /target /install /install/bin; \
+    # build directories for any user
+    mkdir -m 1777 /src /install /cargo; \
     # re-enable apt caching (we have a cache mount)
     rm -f /etc/apt/apt.conf.d/docker-clean; \
     # enable packages from multiple architectures
@@ -40,55 +39,10 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
         zstd \
     ;
 
-# Directories for Rust sources and installed binaries
+# Directories for sources and installed binaries
 VOLUME ["/src", "/install"]
 
-# Install rustup and platform-native target
-#
-#    RUST_VERSIONS: list of version numbers or strings
-#                   like `stable`. The first entry becomes the
-#                   default toolchain version.
-#
-#      RUSTUP_ARCH: native architecture as llvm platform triple
-#
-#   RUSTUP_VERSION: version of rustup to download
-#
-#    RUSTUP_SHA256: checksum for this version of rustup on
-#                   ${RUST_ARCH}.
-#
-# Default values are provided only for x86_64.
-ARG RUST_VERSIONS="stable" \
-    RUSTUP_ARCH="x86_64-unknown-linux-gnu" \
-    RUSTUP_VERSION="1.27.1" \
-    RUSTUP_SHA256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" \
-    RUSTUP_URL=""
+LABEL org.opencontainers.image.source="https://github.com/cbs228/sameold"
+LABEL org.opencontainers.image.description="A minimal debian cross-compiling environment with good glibc compatibility."
 
-# Basic cargo/rust configuration, including a `cargo install`
-# location of `/install`.
-ENV PATH=/install/bin:/usr/local/cargo/bin:$PATH \
-    CARGO_INSTALL_ROOT=/install \
-    CARGO_TARGET_DIR=/target \
-    CARGO_TERM_COLOR=always \
-    RUST_BACKTRACE=1 \
-    RUSTUP_HOME=/usr/local/rustup
-
-# Instructions adapted from official Docker image
-# <https://github.com/rust-lang/docker-rust/blob/master/Dockerfile-slim.template>
-RUN set -eux; \
-    export CARGO_HOME=/usr/local/cargo; \
-    [ -n "${RUSTUP_URL:-}" ] || RUSTUP_URL="https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUSTUP_ARCH}/rustup-init"; \
-    curl -O -sSf "$RUSTUP_URL"; \
-    echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
-    chmod +x rustup-init; \
-    default_rust="$(echo "$RUST_VERSIONS" | cut -f1 -d' ')"; \
-    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain "$default_rust"; \
-    rm rustup-init; \
-    rustup --version; \
-    cargo --version; \
-    rustc --version; \
-    rustup set auto-self-update disable; \
-    echo "$RUST_VERSIONS" | xargs rustup toolchain add --profile minimal; \
-    (umask 022 && echo "$RUSTUP_ARCH" >/etc/rust-native-arch)
-
-# Install scripts
-COPY rootfiles/ /
+WORKDIR "/src"

--- a/.github/container/Dockerfile.rust
+++ b/.github/container/Dockerfile.rust
@@ -1,0 +1,57 @@
+#
+# Debian base image, with platform-native Rust
+#
+
+FROM ghcr.io/cbs228/sameold/builder/base:latest
+
+# Install rustup and platform-native target
+#
+#    RUST_VERSIONS: list of version numbers or strings
+#                   like `stable`. The first entry becomes the
+#                   default toolchain version.
+#
+#      RUSTUP_ARCH: native architecture as llvm platform triple
+#
+#   RUSTUP_VERSION: version of rustup to download
+#
+#    RUSTUP_SHA256: checksum for this version of rustup on
+#                   ${RUST_ARCH}.
+#
+# Default values are provided only for x86_64.
+ARG RUST_VERSIONS="stable" \
+    RUSTUP_ARCH="x86_64-unknown-linux-gnu" \
+    RUSTUP_VERSION="1.27.1" \
+    RUSTUP_SHA256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" \
+    RUSTUP_URL=""
+
+# Basic cargo/rust configuration, including a `cargo install`
+# location of `/install`.
+ENV PATH=/install/bin:/usr/local/cargo/bin:$PATH \
+    CARGO_INSTALL_ROOT=/install \
+    CARGO_HOME=/cargo \
+    CARGO_TERM_COLOR=always \
+    RUST_BACKTRACE=1 \
+    RUSTUP_HOME=/usr/local/rustup
+
+# Instructions adapted from official Docker image
+# <https://github.com/rust-lang/docker-rust/blob/master/Dockerfile-slim.template>
+RUN set -eux; \
+    export CARGO_HOME=/usr/local/cargo; \
+    [ -n "${RUSTUP_URL:-}" ] || RUSTUP_URL="https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUSTUP_ARCH}/rustup-init"; \
+    curl -O -sSf "$RUSTUP_URL"; \
+    echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    default_rust="$(echo "$RUST_VERSIONS" | cut -f1 -d' ')"; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain "$default_rust"; \
+    rm rustup-init; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version; \
+    rustup set auto-self-update disable; \
+    echo "$RUST_VERSIONS" | xargs rustup toolchain add --profile minimal; \
+    (umask 022 && echo "$RUSTUP_ARCH" >/etc/rust-native-arch)
+
+# Install scripts
+COPY rootfiles/ /
+
+LABEL org.opencontainers.image.description="A pinned Rust toolchain with rustup."

--- a/.github/container/Dockerfile.rust.aarch64-unknown-linux-gnu
+++ b/.github/container/Dockerfile.rust.aarch64-unknown-linux-gnu
@@ -2,7 +2,7 @@
 # Debian base image, with arm64 toolchains
 #
 
-FROM ghcr.io/cbs228/sameold/builder.base:latest
+FROM ghcr.io/cbs228/sameold/builder/rust:latest
 
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
@@ -28,5 +28,4 @@ ENV CARGO_BUILD_TARGET="$RUST_TARGET" \
 
 USER builder
 
-LABEL org.opencontainers.image.source="https://github.com/cbs228/sameold"
-LABEL org.opencontainers.image.description="Linux cross-compiling Rust environment for sameold and samedec."
+LABEL org.opencontainers.image.description="A Debian-based Rust cross-compiling environment."

--- a/.github/container/Dockerfile.rust.armv7-unknown-linux-gnueabihf
+++ b/.github/container/Dockerfile.rust.armv7-unknown-linux-gnueabihf
@@ -2,7 +2,7 @@
 # Debian base image, with armhf toolchains
 #
 
-FROM ghcr.io/cbs228/sameold/builder.base:latest
+FROM ghcr.io/cbs228/sameold/builder/rust:latest
 
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
@@ -28,5 +28,4 @@ ENV CARGO_BUILD_TARGET="$RUST_TARGET" \
 
 USER builder
 
-LABEL org.opencontainers.image.source="https://github.com/cbs228/sameold"
-LABEL org.opencontainers.image.description="Linux cross-compiling Rust environment for sameold and samedec."
+LABEL org.opencontainers.image.description="A Debian-based Rust cross-compiling environment."

--- a/.github/container/Dockerfile.rust.i686-unknown-linux-gnu
+++ b/.github/container/Dockerfile.rust.i686-unknown-linux-gnu
@@ -2,7 +2,7 @@
 # Debian base image, with i386 toolchains
 #
 
-FROM ghcr.io/cbs228/sameold/builder.base:latest
+FROM ghcr.io/cbs228/sameold/builder/rust:latest
 
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
@@ -28,5 +28,4 @@ ENV CARGO_BUILD_TARGET="$RUST_TARGET" \
 
 USER builder
 
-LABEL org.opencontainers.image.source="https://github.com/cbs228/sameold"
-LABEL org.opencontainers.image.description="Linux cross-compiling Rust environment for sameold and samedec."
+LABEL org.opencontainers.image.description="A Debian-based Rust cross-compiling environment."

--- a/.github/container/Dockerfile.rust.x86_64-unknown-linux-gnu
+++ b/.github/container/Dockerfile.rust.x86_64-unknown-linux-gnu
@@ -2,7 +2,7 @@
 # Debian base image, with amd64 toolchains
 #
 
-FROM ghcr.io/cbs228/sameold/builder.base:latest
+FROM ghcr.io/cbs228/sameold/builder/rust:latest
 
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
@@ -28,5 +28,4 @@ ENV CARGO_BUILD_TARGET="$RUST_TARGET" \
 
 USER builder
 
-LABEL org.opencontainers.image.source="https://github.com/cbs228/sameold"
-LABEL org.opencontainers.image.description="Linux cross-compiling Rust environment for sameold and samedec."
+LABEL org.opencontainers.image.description="A Debian-based Rust cross-compiling environment."

--- a/.github/container/README.md
+++ b/.github/container/README.md
@@ -1,0 +1,49 @@
+# Rust Cross-Compiling Containers
+
+[cross-rs](https://github.com/cross-rs/cross) splits the build environment into:
+
+1. An "outer" build environment, which contains `cargo` and a toolchain.
+
+2. An "inner" build environment, which includes a gcc cross-compiler, foreign-architecture runtime libraries, and qemu.
+
+If the outer build environment is containerized, this introduces problems. The inner build environment (2) needs access to the host's Docker or podman socket. This can be done, but it does not mesh well with Github Actions' `jobs:*:container` option.
+
+Further, with containers, we want all parts of the build environment:
+
+* Included and ready-to-use
+* Fully-defined by the `Containerfile` and the image's `sha256:` hash
+
+Depending on an external container at runtime defeats some of these design goals.
+
+Instead of using cross-rs, we create our own environment that includes all of these tools. See
+
+```
+./build.sh
+```
+
+to build it. The build instructions are heavily influenced by the cross-rs project but do not depend on it.
+
+You can use any of these containers offline to build samedec. Define the following volumes:
+
+* `/src`: the repository root of a Rust project
+* `/install`: destination for binaries installed with `cargo install`
+* `/src/target` (**optional**): a build directory.
+* `/cargohome` (**optional**): a persistent `$CARGO_HOME` directory
+
+Example:
+
+```bash
+mkdir -p out/aarch64-unknown-linux-gnu
+
+podman run \
+  --security-opt label=disable \
+  --userns=keep-id:uid=1001,gid=1001 \
+  --rm -it \
+  --volume .:/src:ro \
+  --volume ./target:/src/target:rw \
+  --volume ./out/aarch64-unknown-linux-gnu:/install \
+  ghcr.io/cbs228/sameold/builder/aarch64-unknown-linux-gnu \
+  cargo install --path crates/samedec
+```
+
+You should run your build as UID 1001 within the container. The above `--userns` mapping will accomplish this.


### PR DESCRIPTION
* Improve UX when building locally / not on CI:

  * Make in-image `/install` and cargo home directory world-writeable, which helps with permssions issues. Unlike the official rust docker image, we still don't make the rustup and rust toolchain directories world-writeable. Build systems have no business messing with that.

  * Discontinue `/target` target directory. Use the standard cargo target directory of `./target` instead. If the user wants a separate target directory, they can bind-mount one.

* Make `build.sh` easier to read and potentially usable with Docker. Omit the `podman login` step.

* Add README for the images.