### PR TITLE
ci: restore apple x86_64 target

### DIFF
--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -221,19 +221,25 @@ jobs:
         file: ${{ env.samedec_target_exe }}
         overwrite: true
 
-  # MacOS build, on whatever machine github has available
+  # MacOS build, aarch64
   release_macos:
     runs-on: macos-latest
 
     needs: vendor_sources
 
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+          - target: x86_64-apple-darwin
+
     env:
-      CARGO_BUILD_TARGET: aarch64-apple-darwin
+      CARGO_BUILD_TARGET: ${{ matrix.target }}
       CARGO_NET_OFFLINE: "true"
       CARGO_INSTALL_ROOT: "install/"
       RUSTFLAGS: '-C strip=symbols'
       samedec_exe: 'install/bin/samedec'
-      samedec_target_exe: install/bin/samedec-aarch64-apple-darwin
+      samedec_target_exe: install/bin/samedec-${{ matrix.target }}
 
     steps:
     - uses: actions/checkout@v3
@@ -254,6 +260,7 @@ jobs:
     - name: Build
       run: |
         mkdir -p 'install' &&
+        rustup target add "$CARGO_BUILD_TARGET" &&
         cargo fetch --locked &&
         cargo build --offline --tests --frozen --release --workspace
 

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -165,9 +165,14 @@ jobs:
     - name: Run integration tests
       shell: bash
       run: |
-        pushd sample
-        ./test.sh
-        popd
+        pushd sample && ./test.sh && popd
+
+    - name: Cross-compile macOS target for x86_64 (apple only)
+      shell: bash
+      if: ${{ matrix.os == 'macos-latest' }}
+      run: |
+        rustup target add x86_64-apple-darwin && \
+        cargo test --frozen -p samedec --verbose --target=x86_64-apple-darwin
 
   # Linux builds within our containerized release environment
   test_samedec_containerized:

--- a/README.md
+++ b/README.md
@@ -44,13 +44,27 @@ alerts.
 
 Binary builds are available on the
 [releases](https://github.com/cbs228/sameold/releases) page for a variety of
-platforms. Linux binaries are currently built against glibc 2.28 and should be
+platforms, including:
+
+* `aarch64-apple-darwin`
+* `aarch64-unknown-linux-gnu`
+* `armv7-unknown-linux-gnueabihf`
+* `i686-unknown-linux-gnu`
+* `x86_64-pc-windows-msvc`
+* `x86_64-unknown-linux-gnu`
+
+GNU/Linux binaries are currently built for glibc 2.28 and should be
 portable to most distros.
 
 ### Building
 
 You will need a working
 [rust toolchain](https://www.rust-lang.org/learn/get-started).
+
+```bash
+cargo install samedec
+samedec --help
+```
 
 To build and install binaries from this repository, run
 


### PR DESCRIPTION
In [1], we migrated macos builds from x86_64 to aarch64. There are still plenty of x86_64 macs running around, and our CI binaries should support them if we can. Ensure we cross-compile for x86_64 as well.

[1]: 46a0222026abdc922fc1480f9ea103cac65d0300