### PR TITLE
ci: add cargo check and cargo doc checks

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -29,13 +29,10 @@ jobs:
       if: github.event.pull_request.base.sha
       run: |
         git diff --check "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}" || {
-          echo >&2 "Your pull request introduces whitespace errors,";
-          echo >&2 "which is not allowed. Please run:";
-          echo >&2;
-          echo >&2 "    git rebase --whitespace=fix";
-          echo >&2 "    git push -f";
-          echo >&2;
-          echo >&2 "to correct and resubmit.";
+          echo \
+            '::error title={Failed git diff --check}::Your pull request introduces whitespace errors, which is not allowed. Please run:%0A%0A'\
+            '   git rebase --whitespace=fix%0A'\
+            '   git push -f%0A%0Ato correct and resubmit.'
           exit 1;
         }
 
@@ -43,16 +40,11 @@ jobs:
       if: github.event.pull_request.base.sha
       run: |
         cargo fmt --check || { \
-          echo >&2 "Your pull request does not conform to cargo-fmt";
-          echo >&2 "Rust format, which is not allowed. Please run:";
-          echo >&2;
-          echo >&2 "    cargo fmt";
-          echo >&2 "    git commit -a --amend";
-          echo >&2 "    git push -f";
-          echo >&2;
-          echo >&2 "to correct and resubmit. If \`cargo fmt\` touches";
-          echo >&2 "code which is not part of your MR, please let us";
-          echo >&2 "know in the comments.";
+          echo \
+            '::error title={Failed cargo-fmt --check}::Your pull request does not conform to cargo-fmt, which is not allowed. Please run:%0A%0A' \
+            '   cargo fmt%0A' \
+            '   git commit -a --amend%0A' \
+            '   git push -f%0A%0Ato correct and resubmit. If the `cargo fmt` touches code which is not part of your original PR, please let us know in the comments.'
           exit 1;
         }
 
@@ -87,6 +79,30 @@ jobs:
         mkdir -p .cargo
         mkdir -p vendor
         cargo vendor --versioned-dirs --locked >.cargo/config.toml
+
+    - name: Check Rust lints (PRs only)
+      if: github.event.pull_request.base.sha
+      run: |
+        cargo check --frozen --locked --workspace || { \
+          echo \
+            '::error title={Failed cargo-check}::`cargo check` must pass without errors. Please correct Rust compiler lints. When you are finished, please run:%0A%0A' \
+            '    cargo fmt%0A' \
+            '    git commit -a --amend%0A' \
+            '    git push -f%0A%0Ato correct and resubmit. If this requires you to touch code which is not part of your original PR, please let us know in the comments.'
+          exit 1;
+        }
+
+    - name: Check documentation build (PRs only)
+      if: github.event.pull_request.base.sha
+      run: |
+        cargo doc --frozen --locked --no-deps --workspace || { \
+          echo \
+            '::error title={Failed cargo-doc build}::Documentation failed to build. `cargo doc` must be able to generate crate documentation without errors. Please fix. When you are finished, please run:%0A%0A' \
+            '    cargo fmt%0A' \
+            '    git commit -a --amend%0A' \
+            '    git push -f%0A%0Ato correct and resubmit. If this requires you to touch code which is not part of your original PR, please let us know in the comments.'
+          exit 1;
+        }
 
   # test sameold with all crate feature combinations,
   # in our Linux container


### PR DESCRIPTION
Ensure that all PRs pass `cargo check` and `cargo doc` builds before they are gated into the full build matrix.

In addition, we add GHA annotations to improve error messages.
