### PR TITLE
sameold: make assert_approx_eq a dev-dependency

### DIFF
--- a/crates/sameold/Cargo.toml
+++ b/crates/sameold/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 [dependencies]
 arrayvec = "^0.7.1"
 arraydeque = "^0.5"
-assert_approx_eq = "1.1.0"
 lazy_static = "^1.4.0"
 log = "0.4"
 nalgebra = "^0.33.2"
@@ -25,6 +24,9 @@ slice-ring-buffer = "^0.3"
 strum = "^0.26"
 strum_macros = "^0.26"
 thiserror = "^2.0"
+
+[dev-dependencies]
+assert_approx_eq = "1.1.0"
 
 [dependencies.chrono]
 version = "^0.4"


### PR DESCRIPTION
`assert_approx_eq` provides macros for unit tests. This dependency should not propagate to other workspace crates. Make it a dev-dependency instead.