### PR TITLE
ci: use container image for "check and vendor" job

### DIFF
--- a/.github/container/rust/Dockerfile
+++ b/.github/container/rust/Dockerfile
@@ -51,6 +51,7 @@ RUN set -eux; \
     rustc --version; \
     rustup set auto-self-update disable; \
     echo "$RUST_VERSIONS" | xargs rustup toolchain add --profile minimal; \
+    rustup component add --toolchain "$default_rust" rustfmt; \
     (umask 022 && echo "$RUSTUP_ARCH" >/etc/rust-native-arch)
 
 # Install scripts

--- a/.github/container/rust/rootfiles/usr/local/bin/qemu-run-maybe
+++ b/.github/container/rust/rootfiles/usr/local/bin/qemu-run-maybe
@@ -14,8 +14,12 @@ if [ ! -x "$program" ]; then
   program="$(command -v "$program")"
 fi
 
+# determine platform-native triple by reading a file we
+# wrote at install time
+NATIVE_ARCH="$(cat /etc/rust-native-arch)"
+
 case "${CARGO_BUILD_TARGET:-}" in
-  ("$(cat /etc/rust-native-arch)")
+  ("${NATIVE_ARCH?no native architecture saved in /etc/rust-native-arch}")
     # the build target is the native architecture
     exec "$program" "$@"
     ;;
@@ -26,7 +30,15 @@ case "${CARGO_BUILD_TARGET:-}" in
     exec qemu-arm -- "$program" "$@"
     ;;
   (i686-unknown-linux-*)
-    exec qemu-i386 -- "$program" "$@"
+    case "$NATIVE_ARCH" in
+      (x86_64-unknown-linux-*)
+        # x86_64 can run i686 without emulation
+        exec "$program" "$@"
+        ;;
+      (*)
+        exec qemu-i386 -- "$program" "$@"
+        ;;
+    esac
     ;;
   (x86_64-unknown-linux-*)
     exec qemu-x86_64 -- "$program" "$@"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -20,6 +20,14 @@ jobs:
   check_and_vendor:
     runs-on: ubuntu-latest
 
+    container:
+      image: ghcr.io/cbs228/sameold/builder/x86_64-unknown-linux-gnu:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      env:
+        CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Use our homegrown container image for running the initial "check and vendor" job. All Linux jobs now run containerized.

In addition:

* Add cargo-fmt to containers
* Run i686 binaries on x86_64 without emulation