### PR TITLE
sameold: drop slice-ring-buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,15 +335,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
-name = "mach2"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "matrixmultiply"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,7 +612,6 @@ dependencies = [
  "num-complex",
  "num-traits",
  "sameplace",
- "slice-ring-buffer",
 ]
 
 [[package]]
@@ -661,17 +651,6 @@ name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
-
-[[package]]
-name = "slice-ring-buffer"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84ae312bda09b2368f79f985fdb4df4a0b5cbc75546b511303972d195f8c27d6"
-dependencies = [
- "libc",
- "mach2",
- "winapi",
-]
 
 [[package]]
 name = "strsim"
@@ -835,22 +814,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,12 +821,6 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/crates/sameold/Cargo.toml
+++ b/crates/sameold/Cargo.toml
@@ -18,7 +18,6 @@ log = "0.4"
 nalgebra = "^0.33.2"
 num-complex = "^0.4"
 num-traits = "^0.2"
-slice-ring-buffer = "^0.3"
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"

--- a/crates/sameold/src/receiver/dcblock.rs
+++ b/crates/sameold/src/receiver/dcblock.rs
@@ -168,7 +168,7 @@ mod tests {
             output_history.push_scalar(uut.filter(100.0f32 + clk));
             clk = -1.0 * clk;
         }
-        assert_approx_eq!(output_history.as_slice()[0], 1.0f32, 1.0e-2);
-        assert_approx_eq!(output_history.as_slice()[1], -1.0f32, 1.0e-2);
+        assert_approx_eq!(output_history.inner()[0], 1.0f32, 1.0e-2);
+        assert_approx_eq!(output_history.inner()[1], -1.0f32, 1.0e-2);
     }
 }

--- a/crates/sameold/src/receiver/demod.rs
+++ b/crates/sameold/src/receiver/demod.rs
@@ -155,9 +155,8 @@ impl FskDemod {
     // * `< 0` for space
     fn demod_now(&self) -> f32 {
         // matched filter
-        let window = self.window_input.as_slice();
-        let mark = self.coeff_mark.filter(window);
-        let space = self.coeff_space.filter(window);
+        let mark = self.coeff_mark.filter(&self.window_input);
+        let space = self.coeff_space.filter(&self.window_input);
 
         // non-coherently sum matched filter powers to obtain
         // the symbol estimate

--- a/crates/sameold/src/receiver/equalize.rs
+++ b/crates/sameold/src/receiver/equalize.rs
@@ -133,6 +133,9 @@ impl Equalizer {
         let feedforward_wind = Window::new(nfeedforward);
         let feedback_wind = Window::new(nfeedback);
 
+        assert_eq!(feedforward_coeff.inner().len(), feedforward_wind.len());
+        assert_eq!(feedback_coeff.inner().len(), feedback_wind.len());
+
         Self {
             relaxation,
             regularization,
@@ -314,14 +317,16 @@ impl Equalizer {
             self.relaxation,
             self.regularization,
             error,
-            self.feedforward_wind.as_ref(),
+            &self.feedforward_wind,
             self.feedforward_coeff.as_mut(),
         );
+
+        assert_eq!(self.feedback_wind.inner().len(), self.feedback_coeff.len());
         nlms_update(
             self.relaxation,
             self.regularization,
             -error,
-            self.feedback_wind.as_ref(),
+            &self.feedback_wind,
             self.feedback_coeff.as_mut(),
         );
     }
@@ -346,17 +351,14 @@ enum EqualizerState {
 // variable gain. The gain is computed based on the power
 // of the input. The given `filter` taps are updated based
 // on the input samples in `window`.
-fn nlms_update(
-    relaxation: f32,
-    regularization: f32,
-    error: f32,
-    window: &[f32],
-    filter: &mut [f32],
-) {
-    assert_eq!(window.len(), filter.len());
-
-    let gain = nlms_gain(relaxation, regularization, window);
-    for (coeff, data) in filter.iter_mut().zip(window.iter()) {
+fn nlms_update<W>(relaxation: f32, regularization: f32, error: f32, window: W, filter: &mut [f32])
+where
+    W: IntoIterator<Item = f32>,
+    W::IntoIter: DoubleEndedIterator + Clone,
+{
+    let window = window.into_iter();
+    let gain = nlms_gain(relaxation, regularization, window.clone());
+    for (coeff, data) in filter.iter_mut().zip(window) {
         *coeff += gain * error * data;
     }
 }
@@ -371,7 +373,10 @@ fn nlms_update(
 //
 // where `norm(x, 2)` is the L² norm of `x`
 #[inline]
-fn nlms_gain(relaxation: f32, regularization: f32, window: &[f32]) -> f32 {
+fn nlms_gain<'a, W>(relaxation: f32, regularization: f32, window: W) -> f32
+where
+    W: IntoIterator<Item = f32>,
+{
     let mut sumsq = 0.0f32;
     for w in window {
         sumsq += w * w;
@@ -473,7 +478,7 @@ mod tests {
                 RELAXATION,
                 REGULARIZATION,
                 err,
-                inverse_wind.as_ref(),
+                &inverse_wind,
                 inverse_coeff.as_mut(),
             );
         }

--- a/crates/sameold/src/receiver/equalize.rs
+++ b/crates/sameold/src/receiver/equalize.rs
@@ -358,7 +358,7 @@ where
 {
     let window = window.into_iter();
     let gain = nlms_gain(relaxation, regularization, window.clone());
-    for (coeff, data) in filter.iter_mut().zip(window) {
+    for (coeff, data) in filter.iter_mut().zip(window.rev()) {
         *coeff += gain * error * data;
     }
 }


### PR DESCRIPTION
`SliceRingBuffer` is unsound and has multiple security advisories [1] [2]. There has been no apparent progress on fixes since May 2025 [3]. The crate's large volume of interdependent `unsafe` blocks will likely make it very tricky to maintain.

`SliceRingBuffer` backs the FIR filter `Window`. The slice coercion is used to align the back of the `Window` (with the most recent samples) with the FIR filter taps. We don't actually *need* a slice for this: we can get by with a `DoubleEndedIterator` instead.

* Make `Window` convertible to an iterator of numbers, via `IntoIterator`. Replace all uses of slices with iterators.

* Store FIR `FilterCoeff` taps in "proper" order, instead of reversed. Since we use iterators instead of slices, reverse-order is no longer convenient.

* Replace `SliceRingBuffer` with `std::collections::VecDeque`.

Testing indicates that `VecDeque` may be up to twice as fast as the previous implementation.

Closes #53

[1]: https://rustsec.org/advisories/RUSTSEC-2025-0044

[2]: https://rustsec.org/advisories/RUSTSEC-2020-0158

[3]: https://github.com/LiquidityC/slice_ring_buffer/issues/12